### PR TITLE
docs: fix server run command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage
 Running the Server
 
 Start the gRPC server:
-	python server.py
+        python -m distributed_task_manager.server.server
 You should see a log message indicating that the server has started:
 	INFO:Server started on port 50051
  Running the Client


### PR DESCRIPTION
## Summary
- correct server launch command in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'distributed_task_manager')*


------
https://chatgpt.com/codex/tasks/task_e_689bc680f6588333ac57b6c7dff4f8a5